### PR TITLE
sources: refresh threat-intelligence feeds

### DIFF
--- a/blacklists_list.js
+++ b/blacklists_list.js
@@ -1376,7 +1376,10 @@ var blacklist_list = [
         mode: mode.ip_list,
         submode: submode.extract_all,
         comment: "",
-        limit: -1 // Date "in line"
+        limit: -1, // Date "in line"
+        // DShield redirects generic browser user agents to an HTML notice instead
+        // of serving the API response.
+        userAgent: "MalwareWorld/1.3.6 (+https://github.com/malwareworld/MalwareWorld)"
     },
 
     {


### PR DESCRIPTION
<!-- daily-stats-kind: malwareworld -->

<!-- daily-stats-summary: Audited and refreshed MalwareWorld threat-intelligence sources. -->

Automated weekly audit of MalwareWorld threat-intelligence sources.

Research, source-health evidence, and validation summary:
## Audit result

Audited original HEAD `66738df7a3707bc2442aee370ad3383e76c8c557`; no open MalwareWorld pull requests were found.

Inventory: **157 unique definitions** — 82 active and 75 disabled. Active coverage includes 2 allowlists, 14 malware, 21 attacker, 15 reputation, 16 anonymizer, 4 spam, 3 phishing, and 7 adware sources across domain, URL, host, IP, and CIDR parsers.

### Change applied

Repaired the existing [DShield Tor-exit API](https://www.dshield.org/api/threatlist/torexit/) definition in `blacklists_list.js` by configuring MalwareWorld’s descriptive user agent.

Evidence:

- All **290 observations** from June 3–September 1 returned HTTP success but extracted **zero indicators** because the generic browser user agent was redirected to HTML.
- Current generic-UA request: 571-byte HTML response, zero IPs.
- Current descriptive-UA request: HTTP 200 XML, no redirect, **1,814 unique public IPv4 addresses**, zero private/reserved addresses.
- Existing `ip_list`/`extract_all` parsing correctly extracted all 1,814 indicators.
- Upstream `Last-Modified`: September 1, 2026.

### Sources added

None. No candidate satisfied every provenance, redistribution, parser-cleanliness, and meaningful-new-coverage requirement.

### Sources disabled or replaced

None.

The latest metadata showed all 82 active sources loading successfully. Historical failures—including PhishTank’s 285 failures over 88.7 days and shorter Majestic, SBLam, Rutgers, Yoyo, and Tor interruptions—have recovered and currently produce changing data. Stale-looking sources lacked authoritative abandonment evidence. Therefore, none met the retirement threshold.

### Rejected candidates

- [ThreatFox exports](https://threatfox.abuse.ch/export/): desired IP/port export requires an Auth-Key.
- [Threatview downloads](https://threatview.io/Downloads/): reserved IP contamination, malformed domain-like entries, and unclear redistribution terms.
- [SERPRO reputation feed](https://reputation.serpro.gov.br/): 10,442 IPv4 rows and 23.2% novel coverage, but one CGN address and no explicit redistribution permission.
- [Block List Project](https://github.com/blocklistproject/Lists): maintained and licensed, but aggregates 14 upstream families—including providers already cataloged—without sufficiently distinct primary coverage.
- [Phishing.Database](https://github.com/Phishing-Database/Phishing.Database): maintained and MIT-licensed, but its domain feed contains thousands of IPs and malformed hostname forms that the existing parser could mis-extract.
- APNIC Community Honeynet and HoneyLabs: live samples, but unclear redistribution terms and substantial overlap.
- ELLIO community endpoint: now redirects to an HTML platform rather than a raw feed.
- C2-Tracker, ThreatMon, and CriminalIP samples: archived/stale, insufficient, or lacking meaningful coverage.

### Files changed

- `blacklists_list.js` — added the required DShield user agent.
- No changes to `scripts/disabled-blacklists.json`.
- No supporting files outside the two primary catalog files changed.

### Validation

- `node --check blacklists_list.js` — passed.
- `node -e 'JSON.parse(require("fs").readFileSync("scripts/disabled-blacklists.json","utf8")); console.log("disabled JSON: valid")'` — passed.
- `npm run test:unit` — **28/28 passed**.
- `npm test` — exit 0; unit tests passed and smoke generation completed with **0 failed feeds**.
- `MALWAREWORLD_DISABLE_DYNAMIC_BLACKLISTS=1 node /tmp/mw-dshield-live-check.js` — HTTP 200, correct final URL, **1,814 matches**.
- `git diff --check` — passed.
- Final working tree contains only the intended `blacklists_list.js` change.

A catalog repair was warranted; no source addition or retirement was justified.

Generated by the MalwareWorld Source Auditor workflow. Feed additions and retirements require review before merge.
